### PR TITLE
feat: add jgengo.dev and hive.fi as allowed origins

### DIFF
--- a/src/main/java/com/hivestudent/bookme/Config/WebConfig.java
+++ b/src/main/java/com/hivestudent/bookme/Config/WebConfig.java
@@ -13,8 +13,12 @@ public class WebConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOrigins("http://localhost:5173")
-                        .allowedOrigins("https://booking-calendar-chi.vercel.app")
+                        .allowedOriginPatterns(
+                            "http://localhost:5173",
+                            "https://booking-calendar-chi.vercel.app",
+                            "https://*.hive.fi",
+                            "https://*.jgengo.dev"
+                        )
                         .allowedMethods("*")
                         .allowedHeaders("*")
                         .allowCredentials(true);


### PR DESCRIPTION
Let's add jgengo.dev and hive.fi as allowed origins so we prepare the working ground for migration. 